### PR TITLE
Feature/core/vm definition

### DIFF
--- a/crates/sindri-api/src/error.rs
+++ b/crates/sindri-api/src/error.rs
@@ -26,15 +26,40 @@ impl ApiError {
 impl From<VMError> for ApiError {
     fn from(err: VMError) -> Self {
         match err {
-            VMError::VmNotFound(id) => {
-                ApiError::new(StatusCode::NOT_FOUND, format!("VM not found: {}", id))
-            }
-            VMError::VmAlreadyExists(id) => {
-                ApiError::new(StatusCode::CONFLICT, format!("VM already exists: {}", id))
-            }
-            VMError::InvalidConfig(details) => ApiError::new(
+            VMError::VmNotFound(id) => ApiError::new(
+                StatusCode::NOT_FOUND,
+                format!("VM with ID {} not found", id),
+            ),
+            VMError::VmAlreadyExists(id) => ApiError::new(
+                StatusCode::CONFLICT,
+                format!("VM with ID {} already exists", id),
+            ),
+            VMError::CreationFailed(id) => ApiError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to create VM with ID: {}", id),
+            ),
+            VMError::StartFailed(id) => ApiError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to start VM with ID: {}", id),
+            ),
+            VMError::StopFailed(id) => ApiError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to stop VM with ID: {}", id),
+            ),
+            VMError::DeletionFailed(id) => ApiError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to delete VM with ID: {}", id),
+            ),
+            VMError::InvalidState {
+                vm_id,
+                current,
+                expected,
+            } => ApiError::new(
                 StatusCode::BAD_REQUEST,
-                format!("Invalid VM configuration: {}", details),
+                format!(
+                    "VM with ID: {} is in invalid state: current {}, expected: {}",
+                    vm_id, current, expected
+                ),
             ),
         }
     }
@@ -75,53 +100,87 @@ mod tests {
     }
 
     #[test]
-    fn from_sindri_error_vm_not_found() {
+    fn from_vm_error_not_found() {
         let err = VMError::VmNotFound(123);
         let api_err: ApiError = err.into();
         assert_eq!(api_err.status, StatusCode::NOT_FOUND);
-        assert!(api_err.message.contains("VM not found: 123"));
+        assert!(api_err.message.contains("VM with ID 123 not found"));
     }
 
     #[test]
-    fn from_sindri_error_vm_already_exists() {
+    fn from_vm_error_already_exists() {
         let err = VMError::VmAlreadyExists(456);
         let api_err: ApiError = err.into();
         assert_eq!(api_err.status, StatusCode::CONFLICT);
-        assert!(api_err.message.contains("VM already exists: 456"));
+        assert!(api_err.message.contains("VM with ID 456 already exists"));
     }
 
     #[test]
-    fn from_sindri_error_invalid_config() {
-        let err = VMError::InvalidConfig("bad config".to_string());
+    fn from_vm_error_creation_failed() {
+        let err = VMError::CreationFailed(789);
+        let api_err: ApiError = err.into();
+        assert_eq!(api_err.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(api_err.message.contains("Failed to create VM with ID: 789"));
+    }
+
+    #[test]
+    fn from_vm_error_start_failed() {
+        let err = VMError::StartFailed(101);
+        let api_err: ApiError = err.into();
+        assert_eq!(api_err.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(api_err.message.contains("Failed to start VM with ID: 101"));
+    }
+
+    #[test]
+    fn from_vm_error_stop_failed() {
+        let err = VMError::StopFailed(202);
+        let api_err: ApiError = err.into();
+        assert_eq!(api_err.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(api_err.message.contains("Failed to stop VM with ID: 202"));
+    }
+
+    #[test]
+    fn from_vm_error_deletion_failed() {
+        let err = VMError::DeletionFailed(303);
+        let api_err: ApiError = err.into();
+        assert_eq!(api_err.status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(api_err.message.contains("Failed to delete VM with ID: 303"));
+    }
+
+    #[test]
+    fn from_vm_error_invalid_state() {
+        let err = VMError::InvalidState {
+            vm_id: 404,
+            current: "Stopped".to_string(),
+            expected: "Running".to_string(),
+        };
         let api_err: ApiError = err.into();
         assert_eq!(api_err.status, StatusCode::BAD_REQUEST);
-        assert!(
-            api_err
-                .message
-                .contains("Invalid VM configuration: bad config")
-        );
+        assert!(api_err.message.contains("VM with ID: 404"));
+        assert!(api_err.message.contains("current Stopped"));
+        assert!(api_err.message.contains("expected: Running"));
     }
 
     #[test]
-    fn from_anyhow_error_downcast_sindri() {
-        let sindri_err = VMError::VmNotFound(123);
-        let err = anyhow!(sindri_err);
+    fn from_anyhow_error_downcast_vm_error() {
+        let vm_err = VMError::VmNotFound(123);
+        let err = anyhow!(vm_err);
         let api_err: ApiError = err.into();
         assert_eq!(api_err.status, StatusCode::NOT_FOUND);
-        assert!(api_err.message.contains("VM not found: 123"));
+        assert!(api_err.message.contains("VM with ID 123 not found"));
     }
 
     #[test]
-    fn from_anyhow_error_other() {
-        let err = anyhow!("some error");
+    fn from_anyhow_error_generic() {
+        let err = anyhow!("some random error");
         let api_err: ApiError = err.into();
         assert_eq!(api_err.status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(api_err.message, "Internal server error");
     }
 
     #[test]
-    fn into_response_returns_json() {
-        let err = ApiError::new(StatusCode::BAD_REQUEST, "bad request");
+    fn into_response_returns_correct_status() {
+        let err = ApiError::new(StatusCode::BAD_REQUEST, "test error");
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }

--- a/crates/sindri-api/src/v1/vms.rs
+++ b/crates/sindri-api/src/v1/vms.rs
@@ -13,27 +13,27 @@ async fn create_vm() -> Result<Json<&'static str>, ApiError> {
     Ok(Json("Create VM"))
 }
 
-async fn get_vm(Path(vm_id): Path<String>) -> Result<Json<String>, ApiError> {
+async fn get_vm(Path(vm_id): Path<u32>) -> Result<Json<String>, ApiError> {
     Ok(Json(format!("Get VM with ID: {}", vm_id)))
 }
 
-async fn update_vm(Path(vm_id): Path<String>) -> Result<Json<String>, ApiError> {
+async fn update_vm(Path(vm_id): Path<u32>) -> Result<Json<String>, ApiError> {
     Ok(Json(format!("Update VM with ID: {}", vm_id)))
 }
 
-async fn destroy_vm(Path(vm_id): Path<String>) -> Result<Json<String>, ApiError> {
+async fn destroy_vm(Path(vm_id): Path<u32>) -> Result<Json<String>, ApiError> {
     Ok(Json(format!("Destroy VM with ID: {}", vm_id)))
 }
 
-async fn start_vm(Path(vm_id): Path<String>) -> Result<Json<String>, ApiError> {
+async fn start_vm(Path(vm_id): Path<u32>) -> Result<Json<String>, ApiError> {
     Ok(Json(format!("Start VM with ID: {}", vm_id)))
 }
 
-async fn stop_vm(Path(vm_id): Path<String>) -> Result<Json<String>, ApiError> {
+async fn stop_vm(Path(vm_id): Path<u32>) -> Result<Json<String>, ApiError> {
     Ok(Json(format!("Stop VM with ID: {}", vm_id)))
 }
 
-async fn vm_metrics(Path(vm_id): Path<String>) -> Result<Json<String>, ApiError> {
+async fn vm_metrics(Path(vm_id): Path<u32>) -> Result<Json<String>, ApiError> {
     Ok(Json(format!("Metrics for VM with ID: {}", vm_id)))
 }
 
@@ -67,44 +67,44 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_vm() {
-        let path = Path("vm-123".to_string());
+        let path = Path(123);
         let result = get_vm(path).await.unwrap();
-        assert_eq!(result.0, "Get VM with ID: vm-123");
+        assert_eq!(result.0, "Get VM with ID: 123");
     }
 
     #[tokio::test]
     async fn test_update_vm() {
-        let path = Path("vm-456".to_string());
+        let path = Path(456);
         let result = update_vm(path).await.unwrap();
-        assert_eq!(result.0, "Update VM with ID: vm-456");
+        assert_eq!(result.0, "Update VM with ID: 456");
     }
 
     #[tokio::test]
     async fn test_destroy_vm() {
-        let path = Path("vm-789".to_string());
+        let path = Path(789);
         let result = destroy_vm(path).await.unwrap();
-        assert_eq!(result.0, "Destroy VM with ID: vm-789");
+        assert_eq!(result.0, "Destroy VM with ID: 789");
     }
 
     #[tokio::test]
     async fn test_start_vm() {
-        let path = Path("vm-111".to_string());
+        let path = Path(111);
         let result = start_vm(path).await.unwrap();
-        assert_eq!(result.0, "Start VM with ID: vm-111");
+        assert_eq!(result.0, "Start VM with ID: 111");
     }
 
     #[tokio::test]
     async fn test_stop_vm() {
-        let path = Path("vm-222".to_string());
+        let path = Path(222);
         let result = stop_vm(path).await.unwrap();
-        assert_eq!(result.0, "Stop VM with ID: vm-222");
+        assert_eq!(result.0, "Stop VM with ID: 222");
     }
 
     #[tokio::test]
     async fn test_vm_metrics() {
-        let path = Path("vm-333".to_string());
+        let path = Path(333);
         let result = vm_metrics(path).await.unwrap();
-        assert_eq!(result.0, "Metrics for VM with ID: vm-333");
+        assert_eq!(result.0, "Metrics for VM with ID: 333");
     }
 
     #[test]

--- a/crates/sindri-api/tests/vm_test.rs
+++ b/crates/sindri-api/tests/vm_test.rs
@@ -57,7 +57,7 @@ async fn test_get_vm() {
         .oneshot(
             Request::builder()
                 .method(Method::GET)
-                .uri("/api/v1/vms/vm-123")
+                .uri("/api/v1/vms/123")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -68,7 +68,7 @@ async fn test_get_vm() {
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let body_str = String::from_utf8(body.to_vec()).unwrap();
-    assert!(body_str.contains("vm-123"));
+    assert!(body_str.contains("123"));
 }
 
 #[tokio::test]
@@ -79,7 +79,7 @@ async fn test_update_vm() {
         .oneshot(
             Request::builder()
                 .method(Method::PUT)
-                .uri("/api/v1/vms/vm-456")
+                .uri("/api/v1/vms/456")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -90,7 +90,7 @@ async fn test_update_vm() {
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let body_str = String::from_utf8(body.to_vec()).unwrap();
-    assert!(body_str.contains("vm-456"));
+    assert!(body_str.contains("456"));
 }
 
 #[tokio::test]
@@ -101,7 +101,7 @@ async fn test_destroy_vm() {
         .oneshot(
             Request::builder()
                 .method(Method::DELETE)
-                .uri("/api/v1/vms/vm-789")
+                .uri("/api/v1/vms/789")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -112,7 +112,7 @@ async fn test_destroy_vm() {
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let body_str = String::from_utf8(body.to_vec()).unwrap();
-    assert!(body_str.contains("vm-789"));
+    assert!(body_str.contains("789"));
 }
 
 #[tokio::test]
@@ -123,7 +123,7 @@ async fn test_start_vm() {
         .oneshot(
             Request::builder()
                 .method(Method::POST)
-                .uri("/api/v1/vms/vm-111/start")
+                .uri("/api/v1/vms/111/start")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -134,7 +134,7 @@ async fn test_start_vm() {
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let body_str = String::from_utf8(body.to_vec()).unwrap();
-    assert!(body_str.contains("vm-111"));
+    assert!(body_str.contains("111"));
 }
 
 #[tokio::test]
@@ -145,7 +145,7 @@ async fn test_stop_vm() {
         .oneshot(
             Request::builder()
                 .method(Method::POST)
-                .uri("/api/v1/vms/vm-222/stop")
+                .uri("/api/v1/vms/222/stop")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -156,7 +156,7 @@ async fn test_stop_vm() {
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let body_str = String::from_utf8(body.to_vec()).unwrap();
-    assert!(body_str.contains("vm-222"));
+    assert!(body_str.contains("222"));
 }
 
 #[tokio::test]
@@ -167,7 +167,7 @@ async fn test_vm_metrics() {
         .oneshot(
             Request::builder()
                 .method(Method::GET)
-                .uri("/api/v1/vms/vm-333/metrics")
+                .uri("/api/v1/vms/333/metrics")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -178,7 +178,7 @@ async fn test_vm_metrics() {
 
     let body = response.into_body().collect().await.unwrap().to_bytes();
     let body_str = String::from_utf8(body.to_vec()).unwrap();
-    assert!(body_str.contains("vm-333"));
+    assert!(body_str.contains("333"));
 }
 
 #[tokio::test]

--- a/crates/sindri-core/src/errors/mod.rs
+++ b/crates/sindri-core/src/errors/mod.rs
@@ -1,1 +1,8 @@
 pub mod vm;
+
+#[derive(Debug)]
+pub enum SindriError {
+    Vm(vm::VMError),
+}
+
+pub type Result<T> = std::result::Result<T, SindriError>;

--- a/crates/sindri-core/src/errors/vm.rs
+++ b/crates/sindri-core/src/errors/vm.rs
@@ -8,6 +8,22 @@ pub enum VMError {
     #[error("VM already exists: {0}")]
     VmAlreadyExists(u32),
 
-    #[error("Invalid VM configuration: {0}")]
-    InvalidConfig(String),
+    #[error("Invalid VM state: {vm_id}, current: {current}, expected: {expected}")]
+    InvalidState {
+        vm_id: u32,
+        current: String,
+        expected: String,
+    },
+
+    #[error("VM creation failed: {0}")]
+    CreationFailed(u32),
+
+    #[error("VM start failed: {0}")]
+    StartFailed(u32),
+
+    #[error("VM stop failed: {0}")]
+    StopFailed(u32),
+
+    #[error("VM deletion failed: {0}")]
+    DeletionFailed(u32),
 }

--- a/crates/sindri-core/src/errors/vm.rs
+++ b/crates/sindri-core/src/errors/vm.rs
@@ -1,12 +1,12 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub enum SindriError {
+pub enum VMError {
     #[error("VM not found: {0}")]
-    VmNotFound(String),
+    VmNotFound(u32),
 
     #[error("VM already exists: {0}")]
-    VmAlreadyExists(String),
+    VmAlreadyExists(u32),
 
     #[error("Invalid VM configuration: {0}")]
     InvalidConfig(String),

--- a/crates/sindri-core/src/lib.rs
+++ b/crates/sindri-core/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod errors;
+pub mod vm;

--- a/crates/sindri-core/src/vm.rs
+++ b/crates/sindri-core/src/vm.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VM {
+    pub id: u32,
+    pub name: String,
+    pub config: VMConfig,
+    pub network: VMNetwork,
+    pub storage: VMStorage,
+    pub status: VMStatus,
+    pub kernel: KernelConfig,
+    pub runtime: Option<VMRuntime>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VMConfig {
+    pub cpu: u8,
+    pub memory: u64,
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VMNetwork {
+    pub ip_address: String,
+    pub mac_address: String,
+    pub subnet: u8,
+    pub gateway: String,
+    pub dns: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VMStorage {
+    pub disks: Vec<Disk>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VMStatus {
+    Running,
+    Stopped,
+    Paused,
+    Suspended,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Disk {
+    pub id: u32,
+    pub size_gb: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KernelConfig {
+    pub path: String,
+    pub parameters: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VMRuntime {
+    Firecracker(FirecrackerRuntime),
+    CloudHypervisor(CloudHypervisorRuntime),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FirecrackerRuntime {
+    pub pid: u32,
+    pub socket_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CloudHypervisorRuntime {
+    pub pid: u32,
+    pub api_socket: String,
+}


### PR DESCRIPTION
This pull request refactors the VM error handling across the API and core modules, standardizing VM identifiers as `u32` instead of strings and introducing a new, more granular `VMError` type. It also adds a comprehensive VM model to the core crate and updates API endpoints and tests to use the new identifier type. These changes improve type safety, error reporting, and pave the way for richer VM management features.

### Error handling and types

* Replaced the old `SindriError` VM error variant with a dedicated `VMError` enum in `crates/sindri-core/src/errors/vm.rs`, which now covers more VM lifecycle errors and uses `u32` for VM IDs.
* Updated the API error conversion logic in `crates/sindri-api/src/error.rs` to use the new `VMError` type, with improved and more specific error messages for each VM error case. [[1]](diffhunk://#diff-754d8488f04e08e9174d081e65115d848005ea3ea12c5254e3221e27f4ff22bbL9-R9) [[2]](diffhunk://#diff-754d8488f04e08e9174d081e65115d848005ea3ea12c5254e3221e27f4ff22bbL26-R70)
* Added a new top-level `SindriError` enum in `crates/sindri-core/src/errors/mod.rs` to wrap VM errors, and standardized the core crate’s result type.

### VM model enhancements

* Introduced a detailed VM model in `crates/sindri-core/src/vm.rs`, including configuration, network, storage, status, kernel, and runtime details, supporting both Firecracker and Cloud Hypervisor runtimes.
* Registered the new VM model module in the core crate’s library file.

### API and test updates

* Refactored all VM API endpoint handlers in `crates/sindri-api/src/v1/vms.rs` to use `u32` VM IDs instead of strings, updating function signatures and response formats accordingly.
* Updated all related API endpoint tests to use numeric VM IDs and validate the new response formats. [[1]](diffhunk://#diff-0bbdf83d8ed1cf1d55b0ad56e32682794a667349d0b114685a27d614f1c99767L70-R107) [[2]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L60-R60) [[3]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L71-R71) [[4]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L82-R82) [[5]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L93-R93) [[6]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L104-R104) [[7]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L115-R115) [[8]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L126-R126) [[9]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L137-R137) [[10]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L148-R148) [[11]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L159-R159) [[12]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L170-R170) [[13]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L181-R181)

### Test coverage improvements

* Expanded error conversion tests in `crates/sindri-api/src/error.rs` to cover all new `VMError` variants and ensure correct status codes and messages.