### PR TITLE
Feature/daemon/basic daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,6 +545,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "sindri-daemon"
+version = "0.1.0"
+
+[[package]]
 name = "sindri-driver-firecracker"
 version = "0.1.0"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,7 @@ name = "sindri-daemon"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "sindri-core",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,10 @@ dependencies = [
 [[package]]
 name = "sindri-daemon"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "tokio",
+]
 
 [[package]]
 name = "sindri-driver-firecracker"

--- a/crates/sindri-daemon/Cargo.toml
+++ b/crates/sindri-daemon/Cargo.toml
@@ -12,3 +12,5 @@ name = "sindri_daemon"
 path = "src/lib.rs"
 
 [dependencies]
+tokio = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/sindri-daemon/Cargo.toml
+++ b/crates/sindri-daemon/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sindri-daemon"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "sindrid"
+path = "src/main.rs"
+
+[lib]
+name = "sindri_daemon"
+path = "src/lib.rs"
+
+[dependencies]

--- a/crates/sindri-daemon/Cargo.toml
+++ b/crates/sindri-daemon/Cargo.toml
@@ -14,3 +14,4 @@ path = "src/lib.rs"
 [dependencies]
 tokio = { workspace = true }
 anyhow = { workspace = true }
+sindri-core = { workspace = true }

--- a/crates/sindri-daemon/src/lib.rs
+++ b/crates/sindri-daemon/src/lib.rs
@@ -1,0 +1,17 @@
+use sindri_core::vm::VM;
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct Daemon {
+    vms: HashMap<u32, VM>,
+    next_id: u32,
+}
+
+impl Daemon {
+    pub fn new() -> Self {
+        Self {
+            vms: HashMap::new(),
+            next_id: 1,
+        }
+    }
+}

--- a/crates/sindri-daemon/src/lib.rs
+++ b/crates/sindri-daemon/src/lib.rs
@@ -15,3 +15,12 @@ impl Daemon {
         }
     }
 }
+
+impl Default for Daemon {
+    fn default() -> Self {
+        Self {
+            vms: HashMap::new(),
+            next_id: 1,
+        }
+    }
+}

--- a/crates/sindri-daemon/src/main.rs
+++ b/crates/sindri-daemon/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crates/sindri-daemon/src/main.rs
+++ b/crates/sindri-daemon/src/main.rs
@@ -1,3 +1,5 @@
-fn main() {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     println!("Hello, world!");
+    Ok(())
 }

--- a/crates/sindri-daemon/src/main.rs
+++ b/crates/sindri-daemon/src/main.rs
@@ -1,5 +1,43 @@
+use std::{sync::Arc, time::Duration};
+
+use sindri_daemon::Daemon;
+use tokio::{sync::RwLock, time::sleep};
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    println!("Hello, world!");
+    let daemon = Arc::new(RwLock::new(Daemon::new()));
+    println!("Sindri Daemon started. Listening for commands...");
+    println!("{:?}", daemon);
+
+    let unix_daemon = daemon.clone();
+    let unix_listener = tokio::spawn(async move {
+        println!("Starting Unix socket listener...");
+        loop {
+            println!("Daemon state:");
+            println!("{:?}", unix_daemon.read().await);
+            drop(unix_daemon.read().await);
+            sleep(Duration::from_secs(5)).await;
+        }
+    });
+
+    let health_daemon = daemon.clone();
+    let health_listener = tokio::spawn(async move {
+        println!("Starting health check endpoint...");
+        loop {
+            println!("Health check - Daemon state:");
+            println!("{:?}", health_daemon.read().await);
+            drop(health_daemon.read().await);
+            sleep(Duration::from_secs(10)).await;
+        }
+    });
+
+    tokio::select! {
+        _ = unix_listener => {}
+        _ = health_listener => {}
+        _ = tokio::signal::ctrl_c() => {
+            println!("Received Ctrl+C, shutting down...");
+        }
+    }
+
     Ok(())
 }


### PR DESCRIPTION
This pull request introduces the initial implementation of the `sindri-daemon` crate, laying the groundwork for a new daemon process in the project. The changes include new crate configuration, a basic daemon structure, and an asynchronous main entry point with concurrent background tasks.

**New crate setup and structure:**

* Added new crate configuration in `crates/sindri-daemon/Cargo.toml`, specifying package details, binary and library targets, and dependencies.
* Implemented the initial `Daemon` struct in `src/lib.rs`, including a VM registry and basic constructor.

**Asynchronous main process and background tasks:**

* Created `src/main.rs` with an async main function that initializes the daemon, spawns two concurrent background tasks (Unix socket listener and health check endpoint), and handles graceful shutdown on Ctrl+C.