### PR TITLE
Feature/api/unix connection

### DIFF
--- a/crates/sindri-api/src/lib.rs
+++ b/crates/sindri-api/src/lib.rs
@@ -1,4 +1,5 @@
 mod error;
+mod socket;
 mod v1;
 
 use axum::{Json, Router, routing::get};
@@ -8,6 +9,10 @@ pub fn create_app() -> Router {
         .route("/healthz", get(healthz))
         .route("/readyz", get(readyz))
         .nest("/api/v1", v1::router())
+}
+
+pub fn create_socket_client(path: String) -> socket::SocketClient {
+    socket::SocketClient::new(path)
 }
 
 async fn healthz() -> Json<serde_json::Value> {

--- a/crates/sindri-api/src/lib.rs
+++ b/crates/sindri-api/src/lib.rs
@@ -2,13 +2,16 @@ mod error;
 mod socket;
 mod v1;
 
+use socket::SocketClient;
+use std::sync::Arc;
+
 use axum::{Json, Router, routing::get};
 
-pub fn create_app() -> Router {
+pub fn create_app(socket_client: Arc<SocketClient>) -> Router {
     Router::new()
         .route("/healthz", get(healthz))
         .route("/readyz", get(readyz))
-        .nest("/api/v1", v1::router())
+        .nest("/api/v1", v1::router(socket_client))
 }
 
 pub fn create_socket_client(path: String) -> socket::SocketClient {

--- a/crates/sindri-api/src/main.rs
+++ b/crates/sindri-api/src/main.rs
@@ -5,7 +5,7 @@ use tokio::net::TcpListener;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let socket_client = Arc::new(create_socket_client(String::from("/tmp/sindri.sock")));
-    let app = create_app();
+    let app = create_app(socket_client);
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     println!("Listening on {}", addr);
     let listener = TcpListener::bind(addr).await?;

--- a/crates/sindri-api/src/main.rs
+++ b/crates/sindri-api/src/main.rs
@@ -1,9 +1,10 @@
-use sindri_api::create_app;
-use std::net::SocketAddr;
+use sindri_api::{create_app, create_socket_client};
+use std::{net::SocketAddr, sync::Arc};
 use tokio::net::TcpListener;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let socket_client = Arc::new(create_socket_client(String::from("/tmp/sindri.sock")));
     let app = create_app();
     let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
     println!("Listening on {}", addr);

--- a/crates/sindri-api/src/socket.rs
+++ b/crates/sindri-api/src/socket.rs
@@ -1,0 +1,31 @@
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+pub struct SocketClient {
+    pub path: String,
+}
+
+impl Default for SocketClient {
+    fn default() -> Self {
+        SocketClient {
+            path: String::from("/tmp/sindri.sock"),
+        }
+    }
+}
+
+impl SocketClient {
+    pub fn new(path: String) -> Self {
+        SocketClient { path }
+    }
+    pub async fn send_message(&self, message: &str) -> anyhow::Result<String> {
+        let mut stream = tokio::net::UnixStream::connect(&self.path).await?;
+
+        stream.write_all(message.as_bytes()).await?;
+        stream.write_all(b"\n").await?;
+
+        let mut buffer = vec![0u8; 4096];
+        let n = stream.read(&mut buffer).await?;
+
+        let response = String::from_utf8_lossy(&buffer[..n]).to_string();
+        Ok(response)
+    }
+}

--- a/crates/sindri-api/src/v1/router.rs
+++ b/crates/sindri-api/src/v1/router.rs
@@ -1,6 +1,8 @@
-use crate::v1::vms;
+use std::sync::Arc;
+
+use crate::{socket::SocketClient, v1::vms};
 use axum::Router;
 
-pub fn router() -> Router {
-    Router::new().nest("/vms", vms::router())
+pub fn router(socket_client: Arc<SocketClient>) -> Router {
+    Router::new().nest("/vms", vms::router(socket_client))
 }

--- a/crates/sindri-api/tests/health_test.rs
+++ b/crates/sindri-api/tests/health_test.rs
@@ -1,10 +1,14 @@
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use std::sync::Arc;
 use tower::ServiceExt;
 
 #[tokio::test]
 async fn test_healthz_endpoint() {
-    let app = sindri_api::create_app();
+    let socket_client = Arc::new(sindri_api::create_socket_client(String::from(
+        "/tmp/sindri.sock",
+    )));
+    let app = sindri_api::create_app(socket_client);
 
     let response = app
         .oneshot(
@@ -21,7 +25,10 @@ async fn test_healthz_endpoint() {
 
 #[tokio::test]
 async fn test_readyz_endpoint() {
-    let app = sindri_api::create_app();
+    let socket_client = Arc::new(sindri_api::create_socket_client(String::from(
+        "/tmp/sindri.sock",
+    )));
+    let app = sindri_api::create_app(socket_client);
 
     let response = app
         .oneshot(

--- a/crates/sindri-api/tests/vm_test.rs
+++ b/crates/sindri-api/tests/vm_test.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use axum::{
     body::Body,
     http::{Method, Request, StatusCode},
@@ -7,7 +9,10 @@ use tower::ServiceExt;
 
 #[tokio::test]
 async fn test_list_vms() {
-    let app = sindri_api::create_app();
+    let socket_client = Arc::new(sindri_api::create_socket_client(String::from(
+        "/tmp/sindri.sock",
+    )));
+    let app = sindri_api::create_app(socket_client);
 
     let response = app
         .oneshot(
@@ -29,7 +34,10 @@ async fn test_list_vms() {
 
 #[tokio::test]
 async fn test_create_vm() {
-    let app = sindri_api::create_app();
+    let socket_client = Arc::new(sindri_api::create_socket_client(String::from(
+        "/tmp/sindri.sock",
+    )));
+    let app = sindri_api::create_app(socket_client);
 
     let response = app
         .oneshot(
@@ -51,7 +59,10 @@ async fn test_create_vm() {
 
 #[tokio::test]
 async fn test_get_vm() {
-    let app = sindri_api::create_app();
+    let socket_client = Arc::new(sindri_api::create_socket_client(String::from(
+        "/tmp/sindri.sock",
+    )));
+    let app = sindri_api::create_app(socket_client);
 
     let response = app
         .oneshot(
@@ -73,7 +84,10 @@ async fn test_get_vm() {
 
 #[tokio::test]
 async fn test_update_vm() {
-    let app = sindri_api::create_app();
+    let socket_client = Arc::new(sindri_api::create_socket_client(String::from(
+        "/tmp/sindri.sock",
+    )));
+    let app = sindri_api::create_app(socket_client);
 
     let response = app
         .oneshot(
@@ -95,7 +109,10 @@ async fn test_update_vm() {
 
 #[tokio::test]
 async fn test_destroy_vm() {
-    let app = sindri_api::create_app();
+    let socket_client = Arc::new(sindri_api::create_socket_client(String::from(
+        "/tmp/sindri.sock",
+    )));
+    let app = sindri_api::create_app(socket_client);
 
     let response = app
         .oneshot(
@@ -117,7 +134,10 @@ async fn test_destroy_vm() {
 
 #[tokio::test]
 async fn test_start_vm() {
-    let app = sindri_api::create_app();
+    let socket_client = Arc::new(sindri_api::create_socket_client(String::from(
+        "/tmp/sindri.sock",
+    )));
+    let app = sindri_api::create_app(socket_client);
 
     let response = app
         .oneshot(
@@ -139,7 +159,10 @@ async fn test_start_vm() {
 
 #[tokio::test]
 async fn test_stop_vm() {
-    let app = sindri_api::create_app();
+    let socket_client = Arc::new(sindri_api::create_socket_client(String::from(
+        "/tmp/sindri.sock",
+    )));
+    let app = sindri_api::create_app(socket_client);
 
     let response = app
         .oneshot(
@@ -161,7 +184,10 @@ async fn test_stop_vm() {
 
 #[tokio::test]
 async fn test_vm_metrics() {
-    let app = sindri_api::create_app();
+    let socket_client = Arc::new(sindri_api::create_socket_client(String::from(
+        "/tmp/sindri.sock",
+    )));
+    let app = sindri_api::create_app(socket_client);
 
     let response = app
         .oneshot(
@@ -183,7 +209,10 @@ async fn test_vm_metrics() {
 
 #[tokio::test]
 async fn test_invalid_route() {
-    let app = sindri_api::create_app();
+    let socket_client = Arc::new(sindri_api::create_socket_client(String::from(
+        "/tmp/sindri.sock",
+    )));
+    let app = sindri_api::create_app(socket_client);
 
     let response = app
         .oneshot(

--- a/crates/sindri-daemon/src/socket.rs
+++ b/crates/sindri-daemon/src/socket.rs
@@ -1,5 +1,6 @@
 use sindri_daemon::Daemon;
-use std::{path::Path, sync::Arc};
+use std::sync::Arc;
+use tokio::io::AsyncReadExt;
 use tokio::net::UnixListener;
 
 pub struct SocketServer {
@@ -11,7 +12,10 @@ impl SocketServer {
         let socket_path = "/tmp/sindri.sock";
         if let Err(e) = std::fs::remove_file(socket_path) {
             if e.kind() != std::io::ErrorKind::NotFound {
-                eprintln!("Failed to remove existing socket file {}: {}", socket_path, e);
+                eprintln!(
+                    "Failed to remove existing socket file {}: {}",
+                    socket_path, e
+                );
             }
         }
         let listener = UnixListener::bind(socket_path)?;
@@ -37,10 +41,13 @@ impl SocketServer {
     }
 }
 
-async fn handle_client(stream: tokio::net::UnixStream, _daemon: Arc<Daemon>) -> anyhow::Result<()> {
+async fn handle_client(
+    mut stream: tokio::net::UnixStream,
+    _daemon: Arc<Daemon>,
+) -> anyhow::Result<()> {
     println!("Client connected");
     let mut buffer = [0u8; 1024];
-    let n = stream.try_read(&mut buffer)?;
+    let n = stream.read(&mut buffer).await?;
     let message = String::from_utf8_lossy(&buffer[..n]);
     println!("Received message: {}", message);
     Ok(())


### PR DESCRIPTION
This pull request refactors the `sindri-api` crate to introduce a `SocketClient` abstraction for communication over Unix sockets, and updates the VM API endpoints to use this client for backend operations. The changes also ensure proper dependency injection of the socket client throughout the application and tests, improving modularity and testability.

### Socket communication and dependency injection

* Added a new `SocketClient` struct in `socket.rs` that handles sending and receiving messages over a Unix socket, including a `send_message` async method.
* Refactored the application initialization (`create_app`) and routing logic to accept an `Arc<SocketClient>`, enabling dependency injection across the API and tests. [[1]](diffhunk://#diff-777d47c5255bd6d699737acb4ad78afc0b23c2932bbaeb5f9c8601606cfdb25eR2-R18) [[2]](diffhunk://#diff-0dd967ac81cace696d2358b44f616806471b5d3917f393b6bc4cb22abe301177L1-R7) [[3]](diffhunk://#diff-0bbdf83d8ed1cf1d55b0ad56e32682794a667349d0b114685a27d614f1c99767L1-R84) [[4]](diffhunk://#diff-546b93c446d4699ae49b5423c457963e1a091c471d6514bc57842c79949eb28bR3-R11) [[5]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L10-R15)

### VM API endpoint changes

* Updated all VM-related endpoints to use the injected `SocketClient` for backend communication, replacing stub responses with socket message calls (e.g., "LIST_VMS", "CREATE_VM", etc.).
* Modified the VM router to require and propagate the `SocketClient` state, ensuring all handlers have access to the client.

### Test updates

* Refactored all tests to create and inject a `SocketClient` instance, ensuring test isolation and consistency with the new dependency injection pattern. [[1]](diffhunk://#diff-546b93c446d4699ae49b5423c457963e1a091c471d6514bc57842c79949eb28bR3-R11) [[2]](diffhunk://#diff-546b93c446d4699ae49b5423c457963e1a091c471d6514bc57842c79949eb28bL24-R31) [[3]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8R1-R2) [[4]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L10-R15) [[5]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L32-R40) [[6]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L54-R65) [[7]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L76-R90) [[8]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L98-R115) [[9]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L120-R140) [[10]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L142-R165) [[11]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L164-R190) [[12]](diffhunk://#diff-4675e8fa52f9960b5538213dc5b2b1c7e45042dc52d6b69e7477bc41d803f7f8L186-R215) [[13]](diffhunk://#diff-0bbdf83d8ed1cf1d55b0ad56e32682794a667349d0b114685a27d614f1c99767L109-R157)

### Daemon socket server improvements

* Updated the `sindri-daemon` socket server to use async reading for client messages and improved error handling when removing existing socket files. [[1]](diffhunk://#diff-a9f605b6cdbaf22354483aa8fc39e20b5135e96f5539c773a809826506a250b9L2-R3) [[2]](diffhunk://#diff-a9f605b6cdbaf22354483aa8fc39e20b5135e96f5539c773a809826506a250b9L14-R18) [[3]](diffhunk://#diff-a9f605b6cdbaf22354483aa8fc39e20b5135e96f5539c773a809826506a250b9L40-R50)