### PR TITLE
refactor(vm): simplify VM structure by removing unnecessary fields an…

### DIFF
--- a/crates/sindri-api/src/v1/vms.rs
+++ b/crates/sindri-api/src/v1/vms.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use sindri_core::{
     socket::request::SocketRequest,
-    vm::{KernelConfig, VM, VMConfig, VMId, VMNetwork, VMStorage},
+    vm::{KernelConfig, VM, VMId},
 };
 
 async fn list_vms(
@@ -23,23 +23,12 @@ async fn create_vm(
 ) -> Result<Json<String>, ApiError> {
     let vm = VM::new(
         0,
-        "example-vm".to_string(),
-        VMConfig {
-            cpu: 2,
-            memory: 2048,
-            metadata: None,
-        },
-        VMNetwork {
-            ip_address: "".to_string(),
-            mac_address: "".to_string(),
-            subnet: 24,
-            gateway: "".to_string(),
-            dns: vec![],
-        },
-        VMStorage { disks: vec![] },
+        "test".to_string(),
+        4,
+        2048,
         KernelConfig {
-            path: "".to_string(),
             parameters: vec![],
+            path: "/path/to/kernel".to_string(),
         },
     );
     let response = socket_client
@@ -65,24 +54,13 @@ async fn update_vm(
 ) -> Result<Json<String>, ApiError> {
     let vm_id = VMId::from(vm_id);
     let vm = VM::new(
-        vm_id.0,
-        "updated-vm".to_string(),
-        VMConfig {
-            cpu: 4,
-            memory: 4096,
-            metadata: None,
-        },
-        VMNetwork {
-            ip_address: "".to_string(),
-            mac_address: "".to_string(),
-            subnet: 24,
-            gateway: "".to_string(),
-            dns: vec![],
-        },
-        VMStorage { disks: vec![] },
+        0,
+        "test".to_string(),
+        4,
+        2048,
         KernelConfig {
-            path: "".to_string(),
             parameters: vec![],
+            path: "/path/to/kernel".to_string(),
         },
     );
     let response = socket_client

--- a/crates/sindri-core/src/vm.rs
+++ b/crates/sindri-core/src/vm.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -9,33 +7,10 @@ pub struct VMId(pub u32);
 pub struct VM {
     pub id: VMId,
     pub name: String,
-    pub config: VMConfig,
-    pub network: VMNetwork,
-    pub storage: VMStorage,
-    pub status: VMStatus,
-    pub kernel: KernelConfig,
-    pub runtime: Option<VMRuntime>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct VMConfig {
     pub cpu: u8,
     pub memory: u64,
-    pub metadata: Option<HashMap<String, String>>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct VMNetwork {
-    pub ip_address: String,
-    pub mac_address: String,
-    pub subnet: u8,
-    pub gateway: String,
-    pub dns: Vec<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct VMStorage {
-    pub disks: Vec<Disk>,
+    pub status: VMStatus,
+    pub kernel: KernelConfig,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -47,63 +22,20 @@ pub enum VMStatus {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Disk {
-    pub id: u32,
-    pub size_gb: u32,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct KernelConfig {
     pub path: String,
     pub parameters: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum VMRuntime {
-    Firecracker(FirecrackerRuntime),
-    CloudHypervisor(CloudHypervisorRuntime),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct FirecrackerRuntime {
-    pub pid: u32,
-    pub socket_path: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct CloudHypervisorRuntime {
-    pub pid: u32,
-    pub api_socket: String,
-}
-
 impl VM {
-    pub fn new(
-        id: u32,
-        name: String,
-        config: VMConfig,
-        network: VMNetwork,
-        storage: VMStorage,
-        kernel: KernelConfig,
-    ) -> Self {
+    pub fn new(id: u32, name: String, cpu: u8, memory: u64, kernel: KernelConfig) -> Self {
         VM {
             id: VMId(id),
             name,
-            config,
-            network,
-            storage,
-            status: VMStatus::Stopped,
-            kernel,
-            runtime: None,
-        }
-    }
-}
-
-impl VMConfig {
-    pub fn new(cpu: u8, memory: u64, metadata: Option<HashMap<String, String>>) -> Self {
-        VMConfig {
             cpu,
             memory,
-            metadata,
+            status: VMStatus::Stopped,
+            kernel,
         }
     }
 }


### PR DESCRIPTION
This pull request simplifies the `VM` struct and related code by removing several configuration, network, storage, and runtime fields, and updating the VM creation logic accordingly. The changes streamline the VM model, making it easier to work with and maintain.

**VM struct and API simplification:**

* Removed the `VMConfig`, `VMNetwork`, `VMStorage`, and `VMRuntime` structs/enums, along with related fields from the `VM` struct in `sindri-core/src/vm.rs`. Now, `VM` directly holds `cpu`, `memory`, `status`, and `kernel` fields. [[1]](diffhunk://#diff-102d5421093be16acde22443c98a3674d2d2d0d0d5bd391ed6f813537f4c5227L12-R13) [[2]](diffhunk://#diff-102d5421093be16acde22443c98a3674d2d2d0d0d5bd391ed6f813537f4c5227L49-R38)
* Updated the `VM::new` constructor to match the new, simplified `VM` struct signature.
* Refactored API endpoints in `sindri-api/src/v1/vms.rs` (`create_vm` and `update_vm`) to use the new `VM::new` signature and removed references to the deleted configuration, network, and storage types. [[1]](diffhunk://#diff-0bbdf83d8ed1cf1d55b0ad56e32682794a667349d0b114685a27d614f1c99767L26-R31) [[2]](diffhunk://#diff-0bbdf83d8ed1cf1d55b0ad56e32682794a667349d0b114685a27d614f1c99767L68-R63)
* Cleaned up imports in `sindri-api/src/v1/vms.rs` to remove unused types.
* Removed the unused `HashMap` import in `sindri-core/src/vm.rs`.…d updating constructor